### PR TITLE
enforce agent signatures

### DIFF
--- a/docs/source/examples/linear_polymerization.ipynb
+++ b/docs/source/examples/linear_polymerization.ipynb
@@ -98,7 +98,7 @@
     ],
     "metadata": {
         "kernelspec": {
-            "display_name": "standard",
+            "display_name": "kappa",
             "language": "python",
             "name": "python3"
         },

--- a/pykappa/mixture.py
+++ b/pykappa/mixture.py
@@ -29,6 +29,7 @@ class Mixture:
     """
 
     agents: IndexedSet[Agent]
+    signature: Optional[dict[str, frozenset[str]]]  # Agent types and their sites
     _components: Optional[IndexedSet[Component]]  # Components if tracking is enabled
     _embeddings: dict[Component, IndexedSet[Embedding]]  # Cache of embeddings
     _max_embedding_width: int  # Maximum diameter of tracked components
@@ -52,10 +53,10 @@ class Mixture:
     ):
         self.agents = IndexedSet()
         self.agents.create_index("type", lambda a: [a.type])
+        self.signature = None
         self._components = None
         self._embeddings = {}
         self._max_embedding_width = 0
-        self.signature: Optional[dict[str, frozenset[str]]] = None
 
         if track_components:
             self.enable_component_tracking()

--- a/pykappa/mixture.py
+++ b/pykappa/mixture.py
@@ -55,6 +55,7 @@ class Mixture:
         self._components = None
         self._embeddings = {}
         self._max_embedding_width = 0
+        self.signature: Optional[dict[str, frozenset[str]]] = None
 
         if track_components:
             self.enable_component_tracking()
@@ -140,9 +141,37 @@ class Mixture:
             for component in pattern.components:
                 self._add_component(component)
 
+    def _instantiate_agent(self, agent: Agent) -> Agent:
+        """Create a mixture agent from a pattern agent.
+
+        If a signature is set, validates that all sites are known and fills in
+        missing sites with default state (partner='.', state='?').
+        Agent types not present in the signature are unconstrained.
+        """
+        if self.signature is None:
+            return agent.detached()
+
+        known = self.signature.get(agent.type)
+        if known is None:  # type not in signature → unconstrained
+            return agent.detached()
+
+        unknown = {s.label for s in agent} - known
+        if unknown:
+            raise ValueError(
+                f"Agent '{agent.type}' has unknown site(s) {unknown}. "
+                f"Known sites for this type: {known}"
+            )
+
+        existing = {s.label: Site(s.label, s.state, ".") for s in agent}
+        missing = [Site(label, "?", ".") for label in known if label not in existing]
+        new_agent = Agent(agent.type, list(existing.values()) + missing)
+        for site in new_agent:
+            site.agent = new_agent
+        return new_agent
+
     def _add_component(self, component: Component) -> None:
         component_ordered = list(component.agents)
-        new_agents = [agent.detached() for agent in component_ordered]
+        new_agents = [self._instantiate_agent(agent) for agent in component_ordered]
         new_edges = set()
 
         for i, agent in enumerate(component_ordered):

--- a/pykappa/mixture.py
+++ b/pykappa/mixture.py
@@ -145,11 +145,17 @@ class Mixture:
         """Create a mixture agent from a pattern agent, completing its interface from the signature.
 
         Raises:
-            ValueError: If agent has unknown sites not in the signature.
+            ValueError: If agent has unknown sites or an undeclared type.
         """
-        known_sites = None if self.signature is None else self.signature.get(agent.type)
-        if known_sites is None:
+        if not self.signature:
             return agent.detached()
+
+        known_sites = self.signature.get(agent.type)
+        if known_sites is None:
+            raise ValueError(
+                f"Agent type '{agent.type}' is not declared by any rule. "
+                f"Known agent types: {set(self.signature)}"
+            )
 
         unknown_sites = {s.label for s in agent} - known_sites
         if unknown_sites:

--- a/pykappa/mixture.py
+++ b/pykappa/mixture.py
@@ -29,7 +29,6 @@ class Mixture:
     """
 
     agents: IndexedSet[Agent]
-    signature: Optional[dict[str, frozenset[str]]]  # Agent types and their sites
     _components: Optional[IndexedSet[Component]]  # Components if tracking is enabled
     _embeddings: dict[Component, IndexedSet[Embedding]]  # Cache of embeddings
     _max_embedding_width: int  # Maximum diameter of tracked components
@@ -53,7 +52,6 @@ class Mixture:
     ):
         self.agents = IndexedSet()
         self.agents.create_index("type", lambda a: [a.type])
-        self.signature = None
         self._components = None
         self._embeddings = {}
         self._max_embedding_width = 0
@@ -123,7 +121,13 @@ class Mixture:
                 lambda e: [self.components.lookup_one("agent", next(iter(e.values())))],
             )
 
-    def add(self, pattern: Pattern | Component | str, n_copies: int = 1) -> None:
+    def add(
+        self,
+        pattern: Pattern | Component | str,
+        n_copies: int = 1,
+        *,
+        signature: Optional[dict[str, frozenset[str]]] = None,
+    ) -> None:
         """Add instances of a pattern or component to the mixture.
 
         Raises:
@@ -131,7 +135,7 @@ class Mixture:
         """
         if isinstance(pattern, Component):
             for _ in range(n_copies):
-                self._add_component(pattern)
+                self._add_component(pattern, signature)
             return
 
         if isinstance(pattern, str):
@@ -140,22 +144,24 @@ class Mixture:
         assert pattern.instantiable, "Pattern isn't specific enough to instantiate."
         for _ in range(n_copies):
             for component in pattern.components:
-                self._add_component(component)
+                self._add_component(component, signature)
 
-    def _instantiate_agent(self, agent: Agent) -> Agent:
+    def _instantiate_agent(
+        self, agent: Agent, signature: Optional[dict[str, frozenset[str]]]
+    ) -> Agent:
         """Create a mixture agent from a pattern agent, completing its interface from the signature.
 
         Raises:
             ValueError: If agent has unknown sites or an undeclared type.
         """
-        if not self.signature:
+        if not signature:
             return agent.detached()
 
-        known_sites = self.signature.get(agent.type)
+        known_sites = signature.get(agent.type)
         if known_sites is None:
             raise ValueError(
                 f"Agent type '{agent.type}' is not declared by any rule. "
-                f"Known agent types: {set(self.signature)}"
+                f"Known agent types: {set(signature)}"
             )
 
         unknown_sites = {s.label for s in agent} - known_sites
@@ -179,9 +185,15 @@ class Mixture:
             site.agent = new_agent
         return new_agent
 
-    def _add_component(self, component: Component) -> None:
+    def _add_component(
+        self,
+        component: Component,
+        signature: Optional[dict[str, frozenset[str]]] = None,
+    ) -> None:
         component_ordered = list(component.agents)
-        new_agents = [self._instantiate_agent(agent) for agent in component_ordered]
+        new_agents = [
+            self._instantiate_agent(agent, signature) for agent in component_ordered
+        ]
         new_edges = set()
 
         for i, agent in enumerate(component_ordered):

--- a/pykappa/mixture.py
+++ b/pykappa/mixture.py
@@ -142,17 +142,9 @@ class Mixture:
                 self._add_component(component)
 
     def _instantiate_agent(self, agent: Agent) -> Agent:
-        """Create a mixture agent from a pattern agent.
-
-        If a signature is set, validates that all sites are known and fills in
-        missing sites with default state (partner='.', state='?').
-        Agent types not present in the signature are unconstrained.
-        """
-        if self.signature is None:
-            return agent.detached()
-
-        known = self.signature.get(agent.type)
-        if known is None:  # type not in signature → unconstrained
+        """Create a mixture agent from a pattern agent, completing its interface from the signature."""
+        known = None if self.signature is None else self.signature.get(agent.type)
+        if known is None:
             return agent.detached()
 
         unknown = {s.label for s in agent} - known
@@ -163,8 +155,11 @@ class Mixture:
             )
 
         existing = {s.label: Site(s.label, s.state, ".") for s in agent}
-        missing = [Site(label, "?", ".") for label in known if label not in existing]
-        new_agent = Agent(agent.type, list(existing.values()) + missing)
+        new_agent = Agent(
+            agent.type,
+            list(existing.values())
+            + [Site(label, "?", ".") for label in known if label not in existing],
+        )
         for site in new_agent:
             site.agent = new_agent
         return new_agent

--- a/pykappa/mixture.py
+++ b/pykappa/mixture.py
@@ -142,23 +142,31 @@ class Mixture:
                 self._add_component(component)
 
     def _instantiate_agent(self, agent: Agent) -> Agent:
-        """Create a mixture agent from a pattern agent, completing its interface from the signature."""
-        known = None if self.signature is None else self.signature.get(agent.type)
-        if known is None:
+        """Create a mixture agent from a pattern agent, completing its interface from the signature.
+
+        Raises:
+            ValueError: If agent has unknown sites not in the signature.
+        """
+        known_sites = None if self.signature is None else self.signature.get(agent.type)
+        if known_sites is None:
             return agent.detached()
 
-        unknown = {s.label for s in agent} - known
-        if unknown:
+        unknown_sites = {s.label for s in agent} - known_sites
+        if unknown_sites:
             raise ValueError(
-                f"Agent '{agent.type}' has unknown site(s) {unknown}. "
-                f"Known sites for this type: {known}"
+                f"Agent '{agent.type}' has unknown site(s) {unknown_sites}. "
+                f"Known sites for this type: {known_sites}"
             )
 
-        existing = {s.label: Site(s.label, s.state, ".") for s in agent}
+        existing_sites = {s.label: Site(s.label, s.state, ".") for s in agent}
         new_agent = Agent(
             agent.type,
-            list(existing.values())
-            + [Site(label, "?", ".") for label in known if label not in existing],
+            list(existing_sites.values())
+            + [
+                Site(label, "?", ".")
+                for label in known_sites
+                if label not in existing_sites
+            ],
         )
         for site in new_agent:
             site.agent = new_agent

--- a/pykappa/rule.py
+++ b/pykappa/rule.py
@@ -165,10 +165,13 @@ class Rule:
         rule_embedding: dict[Agent, Agent] = {}
 
         for component in self.left.components:
-            component_embeddings = mixture.embeddings(component)
-            assert (
-                len(component_embeddings) > 0
-            ), f"A rule with no valid embeddings was selected: {self}"
+            component_embeddings = (
+                mixture.embeddings(component)
+                if component in mixture._embeddings
+                else list(component.embeddings(mixture))
+            )
+            if not component_embeddings:
+                return None
             component_embedding = random.choice(component_embeddings)
 
             for rule_agent in component_embedding:

--- a/pykappa/system.py
+++ b/pykappa/system.py
@@ -131,7 +131,7 @@ class System:
 
         system = cls(None, rules, observables, variables, seed=seed)
         for init in inits:
-            system.mixture.add(init[1], int(init[0].evaluate(system)))
+            system.add(init[1], int(init[0].evaluate(system)))
         for token_name, amount_expr in token_inits:
             system.tokens[token_name] = float(amount_expr.evaluate(system))
         return system
@@ -183,7 +183,7 @@ class System:
         )
         if mixture is not None:
             for pattern_str, count in mixture.items():
-                system.mixture.add(pattern_str, count)
+                system.add(pattern_str, count)
         return system
 
     def __init__(
@@ -370,7 +370,6 @@ class System:
     def _set_mixture(self, mixture: Mixture) -> None:
         """Set the system's mixture and update tracking."""
         self.mixture = mixture
-        self.mixture.signature = self.signatures
         for rule in self.rules.values():
             self._track_rule(rule)
         for observable in self.observables.values():
@@ -386,6 +385,10 @@ class System:
             **sites: Site name → default state mapping (e.g., a="p", b="u").
         """
         self.site_defaults[agent_type] = sites
+
+    def add(self, pattern: Pattern | Component | str, n_copies: int = 1) -> None:
+        """Add instances of a pattern or component to the mixture using inferred agent signatures."""
+        self.mixture.add(pattern, n_copies, signature=self.signatures)
 
     def add_rule(self, rule: Rule | str, name: Optional[str] = None) -> None:
         """Add a new rule to the system.
@@ -435,7 +438,6 @@ class System:
                 agent.interface[label] = site = Site(label, default_state, ".")
                 site.agent = agent
 
-        self.mixture.signature = new_signature
         self._track_rule(rule)
 
     def remove_rule(self, name: str) -> None:

--- a/pykappa/system.py
+++ b/pykappa/system.py
@@ -177,11 +177,14 @@ class System:
             else {name: Expression.from_kappa(var) for name, var in variables.items()}
         )
 
-        system = cls(None, real_rules, real_observables, real_variables, *args, **kwargs)
+        system = cls(
+            None, real_rules, real_observables, real_variables, *args, **kwargs
+        )
         if mixture is not None:
             for pattern_str, count in mixture.items():
                 system.mixture.add(pattern_str, count)
         return system
+
     def __init__(
         self,
         mixture: Optional[Mixture] = None,
@@ -381,7 +384,9 @@ class System:
             known = new_sig.get(agent.type)
             if known is None:
                 continue
-            for label in known - old_sig.get(agent.type, frozenset()) - {s.label for s in agent}:
+            for label in (
+                known - old_sig.get(agent.type, frozenset()) - {s.label for s in agent}
+            ):
                 site = Site(label, "?", ".")
                 site.agent = agent
                 agent.interface[label] = site

--- a/pykappa/system.py
+++ b/pykappa/system.py
@@ -274,15 +274,17 @@ class System:
         }
 
     @property
-    def signature(self) -> dict[str, frozenset[str]]:
+    def signatures(self) -> dict[str, frozenset[str]]:
         """The complete site interface for each agent type inferrred from all rules."""
-        sig: dict[str, set[str]] = defaultdict(set)
+        sites_by_type: dict[str, set[str]] = defaultdict(set)
         for rule in self.rules.values():
             for pattern in (rule.left, rule.right):
                 for agent in pattern.agents:
                     if agent is not None:
-                        sig[agent.type].update(site.label for site in agent)
-        return {t: frozenset(sites) for t, sites in sig.items()}
+                        sites_by_type[agent.type].update(site.label for site in agent)
+        return {
+            agent_type: frozenset(sites) for agent_type, sites in sites_by_type.items()
+        }
 
     @property
     def tallies_str(self) -> str:
@@ -364,7 +366,7 @@ class System:
     def _set_mixture(self, mixture: Mixture) -> None:
         """Set the system's mixture and update tracking."""
         self.mixture = mixture
-        self.mixture.signature = self.signature
+        self.mixture.signature = self.signatures
         for rule in self.rules.values():
             self._track_rule(rule)
         for observable in self.observables.values():
@@ -394,22 +396,24 @@ class System:
         if type(rule) in [UnimolecularRule, BimolecularRule]:
             self.mixture.enable_component_tracking()
 
-        old_sig = self.signature
+        old_signature = self.signatures
         self.rules[name] = rule
-        new_sig = self.signature
+        new_signature = self.signatures
 
         # Backfill mixture with new sites for existing agents
         for agent in self.mixture.agents:
-            known = new_sig.get(agent.type)
-            if known is None:
+            known_sites = new_signature.get(agent.type)
+            if known_sites is None:
                 continue
             for label in (
-                known - old_sig.get(agent.type, frozenset()) - {s.label for s in agent}
+                known_sites
+                - old_signature.get(agent.type, frozenset())
+                - {s.label for s in agent}
             ):
                 agent.interface[label] = site = Site(label, "?", ".")
                 site.agent = agent
 
-        self.mixture.signature = new_sig
+        self.mixture.signature = new_signature
         self._track_rule(rule)
 
     def remove_rule(self, name: str) -> None:

--- a/pykappa/system.py
+++ b/pykappa/system.py
@@ -405,11 +405,17 @@ class System:
             known_sites = new_signature.get(agent.type)
             if known_sites is None:
                 continue
-            for label in (
+            new_sites = (
                 known_sites
                 - old_signature.get(agent.type, frozenset())
                 - {s.label for s in agent}
-            ):
+            )
+            if new_sites:
+                warnings.warn(
+                    f"Adding rule '{name}' introduced new sites to {agent.type}: {', '.join(sorted(new_sites))}",
+                    RuntimeWarning,
+                )
+            for label in new_sites:
                 agent.interface[label] = site = Site(label, "?", ".")
                 site.agent = agent
 

--- a/pykappa/system.py
+++ b/pykappa/system.py
@@ -9,7 +9,7 @@ from graphviz import Source
 
 from pykappa.mixture import Mixture
 from pykappa.rule import Rule, UnimolecularRule, BimolecularRule
-from pykappa.pattern import Component, Pattern
+from pykappa.pattern import Component, Pattern, Site
 from pykappa.analysis import Monitor
 from pykappa._expression import Expression
 from pykappa._utils import str_table
@@ -177,15 +177,11 @@ class System:
             else {name: Expression.from_kappa(var) for name, var in variables.items()}
         )
 
-        return cls(
-            None if mixture is None else Mixture.from_kappa(mixture),
-            real_rules,
-            real_observables,
-            real_variables,
-            *args,
-            **kwargs,
-        )
-
+        system = cls(None, real_rules, real_observables, real_variables, *args, **kwargs)
+        if mixture is not None:
+            for pattern_str, count in mixture.items():
+                system.mixture.add(pattern_str, count)
+        return system
     def __init__(
         self,
         mixture: Optional[Mixture] = None,
@@ -275,6 +271,22 @@ class System:
         }
 
     @property
+    def signature(self) -> dict[str, frozenset[str]]:
+        """Infer the complete site interface for each agent type from all rules.
+
+        Only agent types with at least one explicitly named site in any rule are
+        included. Types that appear only as ``A()`` (no sites) are unconstrained.
+        """
+        sig: dict[str, set[str]] = defaultdict(set)
+        for rule in self.rules.values():
+            for pattern in (rule.left, rule.right):
+                for agent in pattern.agents:
+                    if agent is not None:
+                        sig[agent.type].update(site.label for site in agent)
+        # ponytail: only constrain types that have at least one declared site
+        return {t: frozenset(sites) for t, sites in sig.items() if sites}
+
+    @property
     def tallies_str(self) -> str:
         """A formatted string showing how many times each rule has been applied."""
         return str_table(
@@ -354,12 +366,25 @@ class System:
     def _set_mixture(self, mixture: Mixture) -> None:
         """Set the system's mixture and update tracking."""
         self.mixture = mixture
+        self.mixture.signature = self.signature
         for rule in self.rules.values():
             self._track_rule(rule)
         for observable in self.observables.values():
             self._track_expression(observable)
         for variable in self.variables.values():
             self._track_expression(variable)
+
+    def _backfill_mixture(self, old_sig: dict[str, frozenset[str]]) -> None:
+        """Add missing sites to existing agents when the signature expands."""
+        new_sig = self.signature
+        for agent in self.mixture.agents:
+            known = new_sig.get(agent.type)
+            if known is None:
+                continue
+            for label in known - old_sig.get(agent.type, frozenset()) - {s.label for s in agent}:
+                site = Site(label, "?", ".")
+                site.agent = agent
+                agent.interface[label] = site
 
     def add_rule(self, rule: Rule | str, name: Optional[str] = None) -> None:
         """Add a new rule to the system.
@@ -383,8 +408,11 @@ class System:
         if type(rule) in [UnimolecularRule, BimolecularRule]:
             self.mixture.enable_component_tracking()
 
-        self._track_rule(rule)
+        old_sig = self.signature
         self.rules[name] = rule
+        self._backfill_mixture(old_sig)
+        self.mixture.signature = self.signature
+        self._track_rule(rule)
 
     def remove_rule(self, name: str) -> None:
         """Remove a rule by setting its rate to zero.

--- a/pykappa/system.py
+++ b/pykappa/system.py
@@ -372,20 +372,6 @@ class System:
         for variable in self.variables.values():
             self._track_expression(variable)
 
-    def _backfill_mixture(self, old_sig: dict[str, frozenset[str]]) -> None:
-        """Add missing sites to existing agents when the signature expands."""
-        new_sig = self.signature
-        for agent in self.mixture.agents:
-            known = new_sig.get(agent.type)
-            if known is None:
-                continue
-            for label in (
-                known - old_sig.get(agent.type, frozenset()) - {s.label for s in agent}
-            ):
-                site = Site(label, "?", ".")
-                site.agent = agent
-                agent.interface[label] = site
-
     def add_rule(self, rule: Rule | str, name: Optional[str] = None) -> None:
         """Add a new rule to the system.
 
@@ -410,8 +396,20 @@ class System:
 
         old_sig = self.signature
         self.rules[name] = rule
-        self._backfill_mixture(old_sig)
-        self.mixture.signature = self.signature
+        new_sig = self.signature
+
+        # Backfill mixture with new sites for existing agents
+        for agent in self.mixture.agents:
+            known = new_sig.get(agent.type)
+            if known is None:
+                continue
+            for label in (
+                known - old_sig.get(agent.type, frozenset()) - {s.label for s in agent}
+            ):
+                agent.interface[label] = site = Site(label, "?", ".")
+                site.agent = agent
+
+        self.mixture.signature = new_sig
         self._track_rule(rule)
 
     def remove_rule(self, name: str) -> None:

--- a/pykappa/system.py
+++ b/pykappa/system.py
@@ -401,6 +401,7 @@ class System:
         new_signature = self.signatures
 
         # Backfill mixture with new sites for existing agents
+        warned_types = set()
         for agent in self.mixture.agents:
             known_sites = new_signature.get(agent.type)
             if known_sites is None:
@@ -410,11 +411,12 @@ class System:
                 - old_signature.get(agent.type, frozenset())
                 - {s.label for s in agent}
             )
-            if new_sites:
+            if new_sites and agent.type not in warned_types:
                 warnings.warn(
                     f"Adding rule '{name}' introduced new sites to {agent.type}: {', '.join(sorted(new_sites))}",
                     RuntimeWarning,
                 )
+                warned_types.add(agent.type)
             for label in new_sites:
                 agent.interface[label] = site = Site(label, "?", ".")
                 site.agent = agent

--- a/pykappa/system.py
+++ b/pykappa/system.py
@@ -193,6 +193,7 @@ class System:
         observables: Optional[dict[str, Expression]] = None,
         variables: Optional[dict[str, Expression]] = None,
         tokens: Optional[dict[str, float]] = None,
+        site_defaults: Optional[dict[str, dict[str, str]]] = None,
         monitor: bool = True,
         seed: Optional[int] = None,
     ):
@@ -203,6 +204,7 @@ class System:
             observables: Dictionary of observable expressions.
             variables: Dictionary of variable expressions.
             tokens: Dictionary of token names to initial values.
+            site_defaults: Maps agent types to site default states.
             monitor: Whether to enable monitoring of simulation history.
             seed: Random seed for reproducibility.
         """
@@ -221,7 +223,7 @@ class System:
 
         self.observables = {} if observables is None else observables
         self.variables = {} if variables is None else variables
-        self.site_defaults = {}
+        self.site_defaults = {} if site_defaults is None else dict(site_defaults)
 
         self._set_mixture(mixture)
         self.time = 0

--- a/pykappa/system.py
+++ b/pykappa/system.py
@@ -275,19 +275,14 @@ class System:
 
     @property
     def signature(self) -> dict[str, frozenset[str]]:
-        """Infer the complete site interface for each agent type from all rules.
-
-        Only agent types with at least one explicitly named site in any rule are
-        included. Types that appear only as ``A()`` (no sites) are unconstrained.
-        """
+        """The complete site interface for each agent type inferrred from all rules."""
         sig: dict[str, set[str]] = defaultdict(set)
         for rule in self.rules.values():
             for pattern in (rule.left, rule.right):
                 for agent in pattern.agents:
                     if agent is not None:
                         sig[agent.type].update(site.label for site in agent)
-        # ponytail: only constrain types that have at least one declared site
-        return {t: frozenset(sites) for t, sites in sig.items() if sites}
+        return {t: frozenset(sites) for t, sites in sig.items()}
 
     @property
     def tallies_str(self) -> str:

--- a/pykappa/system.py
+++ b/pykappa/system.py
@@ -457,8 +457,8 @@ class System:
     def _track_rule(self, rule: Rule) -> None:
         """Track components mentioned in the left hand side of a Rule."""
         for component in rule.left.components:
-            # TODO: For efficiency check for isomorphism with already-tracked components
-            self.mixture._track_component(component)
+            if component not in self.mixture._embeddings:
+                self.mixture._track_component(component)
 
     def _track_expression(self, expression: Expression) -> None:
         """Track the Components in the given expression.
@@ -514,6 +514,23 @@ class System:
         # Update monitor
         if self.monitor is not None:
             self.monitor.update()
+
+    def apply(self, transformation: str, n: int = 1) -> None:
+        """Apply a transformation immediately for a specified number of times.
+
+        Unlike `update`, this does not advance simulation time or use stochastic
+        selection — the rule fires exactly ``n`` times using randomly chosen
+        embeddings.
+
+        Args:
+            transformation: Kappa string representation of the rule.
+            n: Number of times to apply the rule.
+        """
+        rule = Rule.from_kappa(transformation + " @ 0")
+        for _ in range(n):
+            update = Rule._select(rule, self.mixture)
+            if update is not None:
+                self.mixture._apply_update(update)
 
     def update_via_kasim(self, time: float) -> None:
         """Simulate for a given amount of time using KaSim.

--- a/pykappa/system.py
+++ b/pykappa/system.py
@@ -22,6 +22,7 @@ class System:
     rules: dict[str, Rule]  #: Maps rule names to Rule objects
     observables: dict[str, Expression]  #: Maps observable names to expressions
     variables: dict[str, Expression]  #: Maps variable names to expressions
+    site_defaults: dict[str, dict[str, str]]  #: Maps agent types to site default states
     tokens: dict[str, float]  #: Maps token names to their current values
     monitor: Optional["Monitor"]  #: Optionally tracks simulation history
     time: float  #: Current simulation time
@@ -220,6 +221,7 @@ class System:
 
         self.observables = {} if observables is None else observables
         self.variables = {} if variables is None else variables
+        self.site_defaults = {}
 
         self._set_mixture(mixture)
         self.time = 0
@@ -374,6 +376,15 @@ class System:
         for variable in self.variables.values():
             self._track_expression(variable)
 
+    def set_site_defaults(self, agent_type: str, **sites) -> None:
+        """Set default states for sites of an agent type.
+
+        Args:
+            agent_type: Name of the agent type.
+            **sites: Site name → default state mapping (e.g., a="p", b="u").
+        """
+        self.site_defaults[agent_type] = sites
+
     def add_rule(self, rule: Rule | str, name: Optional[str] = None) -> None:
         """Add a new rule to the system.
 
@@ -418,7 +429,8 @@ class System:
                 )
                 warned_types.add(agent.type)
             for label in new_sites:
-                agent.interface[label] = site = Site(label, "?", ".")
+                default_state = self.site_defaults.get(agent.type, {}).get(label, "?")
+                agent.interface[label] = site = Site(label, default_state, ".")
                 site.agent = agent
 
         self.mixture.signature = new_signature

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -32,7 +32,14 @@ def test_rule_n_embeddings_at_system_initialiation(test_case):
     )
     rule_pattern = Pattern.from_kappa(rule_pattern_str)
     rule = rule_class(rule_pattern, rule_pattern, Expression.from_kappa("1.0"))
-    system = System.from_kappa({mixture_pattern_str: n_copies}, [rule.kappa_str])
+    system = System.from_kappa(
+        {mixture_pattern_str: n_copies},
+        [
+            rule.kappa_str,
+            "., . -> A(a[.], a1[.], a2[.]), B(b[.], b1[.], b2[.]) @ 1",
+        ],  # the second rule is to specify the agent signatures
+        [],
+    )
     assert system.rules["r0"].n_embeddings(system.mixture) == n_embeddings
 
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -413,93 +413,59 @@ def test_monitor_measure():
     assert system.monitor.measure("A") == system["A"]
 
 
-# Signature inference
-
-
-def test_signature_inference_from_rule():
-    s = System.from_kappa(rules=["A(x[.]), B(x[.]) <-> A(x[1]), B(x[1]) @ 1.0, 1.0"])
-    assert s.signature == {"A": frozenset({"x"}), "B": frozenset({"x"})}
-
-
-def test_signature_inference_across_rules():
-    s = System.from_kappa(
-        rules=[
-            "A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0",
-            "A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0",
-        ]
-    )
-    assert s.signature["A"] == frozenset({"x", "y"})
-
-
-def test_signature_enforces_blank_interfaces():
-    s = System.from_kappa(rules=["A(), B() -> A(), B() @ 1.0"])
-    assert s.signature == {"A": frozenset(), "B": frozenset()}
-
-
-def test_signature_updates_after_add_rule():
-    s = System.from_kappa(rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"])
-    assert "y" not in s.signature.get("A", frozenset())
-    s.add_rule("A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0")
-    assert "y" in s.signature["A"]
-
-
-# Signature: completion of interfaces
-
-
-def test_new_rule_fills_missing_sites():
-    s = System.from_kappa(
-        rules=[
-            "A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0",
-            "A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0",
-        ]
-    )
-    s.mixture.add("A()", 1)
-    a = next(iter(s.mixture.agents))
-    assert {"x", "y"} <= set(a.interface)
-
-
-def test_autocomplete_interface_while_adding_agent():
-    s = System.from_kappa(rules=["A(x[.] y[.]) <-> A(x[1] y[1]) @ 1, 1"])
-    s.mixture.add("A(x[.])", 1)
-    a = next(iter(s.mixture.agents))
-    assert "x" in a.interface
-    assert "y" in a.interface
-    assert a["y"].partner == "."
-
-
-def test_completion_via_from_kappa_init():
-    s = System.from_kappa(
+def test_signature_drives_interface_completion():
+    system = System.from_kappa(
         {"A()": 3},
+        rules=[
+            "A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0",
+            "A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0",
+        ],
+    )
+    assert system.signature["A"] == frozenset({"x", "y"})
+    for agent in system.mixture.agents:
+        assert {"x", "y"} <= set(agent.interface)
+    system.mixture.add("A(x[.])", 1)
+    agent = next(a for a in system.mixture.agents if "y" in a.interface)
+    assert agent["y"].partner == "."
+    Mixture().add("A(x[1]), B(y[1])")  # bare mixture: no constraints
+
+
+def test_signature_expands_on_add_rule():
+    system = System.from_kappa(
+        {"A()": 1},
         rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"],
     )
-    for agent in s.mixture.agents:
-        assert "x" in agent.interface
-
-
-def test_interfaces_in_bare_mixture_unconstrained():
-    Mixture().add("A(x[1]), B(y[1])")  # no error
-
-
-# Signatures: reject unknown sites
-
-
-def test_reject_unknown_site():
-    s = System.from_kappa(rules=["A(x[.]), B(x[.]) <-> A(x[1]), B(x[1]) @ 1.0, 1.0"])
     with pytest.raises(ValueError, match="unknown site"):
-        s.mixture.add("A(y[.])", 1)
+        system.mixture.add("A(y[.])", 1)
+    system.add_rule("A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0")
+    assert "y" in system.signature["A"]
+    assert all("y" in a.interface for a in system.mixture.agents if a.type == "A")
+    system.mixture.add("A(y[.])", 1)  # no error now
 
 
-def test_reject_unknown_site_from_ka_init():
+@pytest.mark.parametrize(
+    "make_system",
+    [
+        lambda: System.from_kappa(
+            rules=["A(x[.]), B(x[.]) <-> A(x[1]), B(x[1]) @ 1.0, 1.0"]
+        ),
+        lambda: System.from_ka("A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"),
+    ],
+)
+def test_signature_rejects_unknown_sites(make_system):
     with pytest.raises(ValueError, match="unknown site"):
-        System.from_ka("""
-            A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0
-            %init: 1 A(y[.])
-        """)
+        make_system().mixture.add("A(y[.])", 1)
 
 
-def test_reject_unknown_site_then_add_rule():
-    s = System.from_kappa(rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"])
+@pytest.mark.parametrize(
+    "make_system",
+    [
+        lambda: System.from_kappa(
+            rules=["A(x[.]), B(x[.]) <-> A(x[1]), B(x[1]) @ 1.0, 1.0"]
+        ),
+        lambda: System.from_ka("A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"),
+    ],
+)
+def test_signature_rejects_unknown_sites(make_system):
     with pytest.raises(ValueError, match="unknown site"):
-        s.mixture.add("A(y[.])", 1)
-    s.add_rule("A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0")
-    s.mixture.add("A(y[.])", 1)  # no error
+        make_system().mixture.add("A(y[.])", 1)

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -431,9 +431,9 @@ def test_signature_inference_across_rules():
     assert s.signature["A"] == frozenset({"x", "y"})
 
 
-def test_signature_excludes_types_with_no_sites():
+def test_signature_enforces_blank_interfaces():
     s = System.from_kappa(rules=["A(), B() -> A(), B() @ 1.0"])
-    assert s.signature == {}
+    assert s.signature == {"A": frozenset(), "B": frozenset()}
 
 
 def test_signature_updates_after_add_rule():
@@ -474,11 +474,6 @@ def test_completion_via_from_kappa_init():
     )
     for agent in s.mixture.agents:
         assert "x" in agent.interface
-
-
-def test_unconstrained_type_accepts_any_site():
-    s = System.from_kappa(rules=["A(), B() -> A(), B() @ 1.0"])
-    s.mixture.add("A(z[.])", 1)  # no error
 
 
 def test_interfaces_in_bare_mixture_unconstrained():

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -4,7 +4,7 @@ import itertools
 import random
 from collections import defaultdict
 
-from pykappa import System
+from pykappa import System, Mixture
 from pykappa.rule import AVOGADRO, DIFFUSION_RATE
 
 
@@ -411,3 +411,157 @@ def test_monitor_measure():
     first_time = system.monitor.history["time"][0]
     assert system.monitor.measure("A", first_time) == 100
     assert system.monitor.measure("A") == system["A"]
+
+
+# Signature inference
+
+
+def test_signature_inferred_from_rule_sites():
+    s = System.from_kappa(rules=["A(x[.]), B(x[.]) <-> A(x[1]), B(x[1]) @ 1.0, 1.0"])
+    assert s.signature == {"A": frozenset({"x"}), "B": frozenset({"x"})}
+
+
+def test_signature_union_across_rules():
+    """All sites mentioned for a type across any rule are collected."""
+    s = System.from_kappa(
+        rules=[
+            "A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0",
+            "A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0",
+        ]
+    )
+    assert s.signature["A"] == frozenset({"x", "y"})
+
+
+def test_signature_excludes_types_with_no_sites():
+    """Agent types that only appear as A() (no sites) are not constrained."""
+    s = System.from_kappa(rules=["A(), B() -> A(), B() @ 1.0"])
+    assert "A" not in s.signature
+    assert "B" not in s.signature
+
+
+def test_signature_empty_when_no_rules():
+    s = System.from_kappa()
+    assert s.signature == {}
+
+
+def test_signature_updates_after_add_rule():
+    s = System.from_kappa(rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"])
+    assert "y" not in s.signature.get("A", frozenset())
+    s.add_rule("A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0")
+    assert "y" in s.signature["A"]
+
+
+# Signature: completion of interfaces
+
+
+def test_completion_fills_missing_site():
+    """Adding A() to mixture when signature declares A has site x → A(x[.])."""
+    s = System.from_kappa(rules=["A(x[.]), B(x[.]) <-> A(x[1]), B(x[1]) @ 1.0, 1.0"])
+    s.mixture.add("A()", 1)
+    a = next(iter(s.mixture.agents))
+    assert "x" in a.interface
+
+
+def test_completion_fills_multiple_missing_sites():
+    s = System.from_kappa(
+        rules=[
+            "A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0",
+            "A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0",
+        ]
+    )
+    s.mixture.add("A()", 1)
+    a = next(iter(s.mixture.agents))
+    assert {"x", "y"} <= set(a.interface)
+
+
+def test_completion_preserves_specified_site_state():
+    s = System.from_kappa(rules=["A(x[.] y[.]) <-> A(x[1] y[1]) @ 1.0, 1.0"])
+    s.mixture.add("A(x[.])", 1)
+    a = next(iter(s.mixture.agents))
+    # x was specified; y was missing and should have been added
+    assert "x" in a.interface
+    assert "y" in a.interface
+
+
+def test_completion_via_from_kappa_init():
+    """Agents added via from_kappa mixture dict are also completed."""
+    s = System.from_kappa(
+        {"A()": 3},
+        rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"],
+    )
+    for agent in s.mixture.agents:
+        if agent.type == "A":
+            assert "x" in agent.interface
+
+
+def test_completed_site_defaults_to_unbound():
+    """A site added by completion should default to unbound ('.')."""
+    s = System.from_kappa(rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"])
+    s.mixture.add("A()", 1)
+    a = next(iter(s.mixture.agents))
+    assert a["x"].partner == "."
+
+
+def test_unconstrained_type_accepts_any_site():
+    """A type that appears only as A() in rules has no site constraint."""
+    s = System.from_kappa(rules=["A(), B() -> A(), B() @ 1.0"])
+    s.mixture.add("A(z[.])", 1)  # no error
+
+
+def test_no_signature_mixture_unconstrained():
+    """A bare Mixture (no system, no signature) accepts any agent."""
+    m = Mixture()
+    m.add("A(x[1]), B(y[1])")  # no error
+
+
+# Signatures: reject unknown sites
+
+
+def test_reject_unknown_site():
+    s = System.from_kappa(rules=["A(x[.]), B(x[.]) <-> A(x[1]), B(x[1]) @ 1.0, 1.0"])
+    with pytest.raises(ValueError, match="unknown site"):
+        s.mixture.add("A(y[.])", 1)
+
+
+def test_reject_unknown_site_from_kappa_init():
+    with pytest.raises(ValueError, match="unknown site"):
+        System.from_kappa(
+            {"A(y[.])": 1},
+            rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"],
+        )
+
+
+def test_reject_unknown_site_from_ka_init():
+    with pytest.raises(ValueError, match="unknown site"):
+        System.from_ka("""
+            A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0
+            %init: 1 A(y[.])
+        """)
+
+
+def test_reject_unknown_site_after_add_rule():
+    """Signature grows when a rule is added; prior unknown sites stay invalid."""
+    s = System.from_kappa(rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"])
+    # y is unknown before add_rule
+    with pytest.raises(ValueError, match="unknown site"):
+        s.mixture.add("A(y[.])", 1)
+    # add a rule that declares y
+    s.add_rule("A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0")
+    s.mixture.add("A(y[.])", 1)  # now valid
+
+
+def test_backfill_existing_agents_after_add_rule():
+    """Existing mixture agents get missing sites when the signature expands."""
+    s = System.from_kappa(
+        {"A()": 2},
+        rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"],
+    )
+    for a in s.mixture.agents:
+        if a.type == "A":
+            assert "x" in a.interface
+            assert "y" not in a.interface
+    s.add_rule("A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0")
+    for a in s.mixture.agents:
+        if a.type == "A":
+            assert "y" in a.interface
+            assert a["y"].partner == "."

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -458,9 +458,9 @@ def test_signature_rejects_unknown_sites(make_system):
         make_system().mixture.add("A(y[.])", 1)
 
 
-def test_undeclared_agent_type_rejected():
-    system = System.from_kappa(rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"])
+def test_undeclared_agent_and_site_rejected():
+    system = System.from_kappa(rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1"])
+    with pytest.raises(ValueError, match="unknown site"):
+        system.mixture.add("A(y[.])")
     with pytest.raises(ValueError, match="not declared"):
-        system.mixture.add("A(y[.])", 1)
-    with pytest.raises(ValueError, match="not declared"):
-        system.mixture.add("C()", 1)
+        system.mixture.add("C()")

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -423,7 +423,7 @@ def test_signature_drives_interface_completion():
     assert system.signatures["A"] == frozenset({"x", "y"})
     for agent in system.mixture.agents:
         assert {"x", "y"} <= set(agent.interface)
-    system.mixture.add("A(x[.])", 1)
+    system.add("A(x[.])", 1)
     agent = next(a for a in system.mixture.agents if "y" in a.interface)
     assert agent["y"].partner == "."
     Mixture().add("A(x[1]), B(y[1])")  # bare mixture: no constraints
@@ -435,14 +435,14 @@ def test_signature_expands_on_add_rule():
         rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"],
     )
     with pytest.raises(ValueError, match="unknown site"):
-        system.mixture.add("A(y[.])", 1)
+        system.add("A(y[.])", 1)
     with pytest.raises(ValueError, match="not declared"):
-        system.mixture.add("D()", 1)
+        system.add("D()", 1)
     with pytest.warns(RuntimeWarning, match="introduced new sites to A: y"):
         system.add_rule("A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0")
     assert "y" in system.signatures["A"]
     assert all("y" in a.interface for a in system.mixture.agents if a.type == "A")
-    system.mixture.add("A(y[.])", 1)  # no error now
+    system.add("A(y[.])", 1)  # no error now
 
 
 @pytest.mark.parametrize(
@@ -456,15 +456,15 @@ def test_signature_expands_on_add_rule():
 )
 def test_signature_rejects_unknown_sites(make_system):
     with pytest.raises(ValueError, match="unknown site"):
-        make_system().mixture.add("A(y[.])", 1)
+        make_system().add("A(y[.])", 1)
 
 
 def test_undeclared_agent_and_site_rejected():
     system = System.from_kappa(rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1"])
     with pytest.raises(ValueError, match="unknown site"):
-        system.mixture.add("A(y[.])")
+        system.add("A(y[.])")
     with pytest.raises(ValueError, match="not declared"):
-        system.mixture.add("C()")
+        system.add("C()")
 
 
 def test_site_defaults():

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -416,13 +416,12 @@ def test_monitor_measure():
 # Signature inference
 
 
-def test_signature_inferred_from_rule_sites():
+def test_signature_inference_from_rule():
     s = System.from_kappa(rules=["A(x[.]), B(x[.]) <-> A(x[1]), B(x[1]) @ 1.0, 1.0"])
     assert s.signature == {"A": frozenset({"x"}), "B": frozenset({"x"})}
 
 
-def test_signature_union_across_rules():
-    """All sites mentioned for a type across any rule are collected."""
+def test_signature_inference_across_rules():
     s = System.from_kappa(
         rules=[
             "A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0",
@@ -433,14 +432,7 @@ def test_signature_union_across_rules():
 
 
 def test_signature_excludes_types_with_no_sites():
-    """Agent types that only appear as A() (no sites) are not constrained."""
     s = System.from_kappa(rules=["A(), B() -> A(), B() @ 1.0"])
-    assert "A" not in s.signature
-    assert "B" not in s.signature
-
-
-def test_signature_empty_when_no_rules():
-    s = System.from_kappa()
     assert s.signature == {}
 
 
@@ -454,15 +446,7 @@ def test_signature_updates_after_add_rule():
 # Signature: completion of interfaces
 
 
-def test_completion_fills_missing_site():
-    """Adding A() to mixture when signature declares A has site x → A(x[.])."""
-    s = System.from_kappa(rules=["A(x[.]), B(x[.]) <-> A(x[1]), B(x[1]) @ 1.0, 1.0"])
-    s.mixture.add("A()", 1)
-    a = next(iter(s.mixture.agents))
-    assert "x" in a.interface
-
-
-def test_completion_fills_multiple_missing_sites():
+def test_new_rule_fills_missing_sites():
     s = System.from_kappa(
         rules=[
             "A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0",
@@ -474,44 +458,31 @@ def test_completion_fills_multiple_missing_sites():
     assert {"x", "y"} <= set(a.interface)
 
 
-def test_completion_preserves_specified_site_state():
-    s = System.from_kappa(rules=["A(x[.] y[.]) <-> A(x[1] y[1]) @ 1.0, 1.0"])
+def test_autocomplete_interface_while_adding_agent():
+    s = System.from_kappa(rules=["A(x[.] y[.]) <-> A(x[1] y[1]) @ 1, 1"])
     s.mixture.add("A(x[.])", 1)
     a = next(iter(s.mixture.agents))
-    # x was specified; y was missing and should have been added
     assert "x" in a.interface
     assert "y" in a.interface
+    assert a["y"].partner == "."
 
 
 def test_completion_via_from_kappa_init():
-    """Agents added via from_kappa mixture dict are also completed."""
     s = System.from_kappa(
         {"A()": 3},
         rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"],
     )
     for agent in s.mixture.agents:
-        if agent.type == "A":
-            assert "x" in agent.interface
-
-
-def test_completed_site_defaults_to_unbound():
-    """A site added by completion should default to unbound ('.')."""
-    s = System.from_kappa(rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"])
-    s.mixture.add("A()", 1)
-    a = next(iter(s.mixture.agents))
-    assert a["x"].partner == "."
+        assert "x" in agent.interface
 
 
 def test_unconstrained_type_accepts_any_site():
-    """A type that appears only as A() in rules has no site constraint."""
     s = System.from_kappa(rules=["A(), B() -> A(), B() @ 1.0"])
     s.mixture.add("A(z[.])", 1)  # no error
 
 
-def test_no_signature_mixture_unconstrained():
-    """A bare Mixture (no system, no signature) accepts any agent."""
-    m = Mixture()
-    m.add("A(x[1]), B(y[1])")  # no error
+def test_interfaces_in_bare_mixture_unconstrained():
+    Mixture().add("A(x[1]), B(y[1])")  # no error
 
 
 # Signatures: reject unknown sites
@@ -523,14 +494,6 @@ def test_reject_unknown_site():
         s.mixture.add("A(y[.])", 1)
 
 
-def test_reject_unknown_site_from_kappa_init():
-    with pytest.raises(ValueError, match="unknown site"):
-        System.from_kappa(
-            {"A(y[.])": 1},
-            rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"],
-        )
-
-
 def test_reject_unknown_site_from_ka_init():
     with pytest.raises(ValueError, match="unknown site"):
         System.from_ka("""
@@ -539,29 +502,9 @@ def test_reject_unknown_site_from_ka_init():
         """)
 
 
-def test_reject_unknown_site_after_add_rule():
-    """Signature grows when a rule is added; prior unknown sites stay invalid."""
+def test_reject_unknown_site_then_add_rule():
     s = System.from_kappa(rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"])
-    # y is unknown before add_rule
     with pytest.raises(ValueError, match="unknown site"):
         s.mixture.add("A(y[.])", 1)
-    # add a rule that declares y
     s.add_rule("A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0")
-    s.mixture.add("A(y[.])", 1)  # now valid
-
-
-def test_backfill_existing_agents_after_add_rule():
-    """Existing mixture agents get missing sites when the signature expands."""
-    s = System.from_kappa(
-        {"A()": 2},
-        rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"],
-    )
-    for a in s.mixture.agents:
-        if a.type == "A":
-            assert "x" in a.interface
-            assert "y" not in a.interface
-    s.add_rule("A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0")
-    for a in s.mixture.agents:
-        if a.type == "A":
-            assert "y" in a.interface
-            assert a["y"].partner == "."
+    s.mixture.add("A(y[.])", 1)  # no error

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -421,7 +421,7 @@ def test_signature_drives_interface_completion():
             "A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0",
         ],
     )
-    assert system.signature["A"] == frozenset({"x", "y"})
+    assert system.signatures["A"] == frozenset({"x", "y"})
     for agent in system.mixture.agents:
         assert {"x", "y"} <= set(agent.interface)
     system.mixture.add("A(x[.])", 1)
@@ -438,7 +438,7 @@ def test_signature_expands_on_add_rule():
     with pytest.raises(ValueError, match="unknown site"):
         system.mixture.add("A(y[.])", 1)
     system.add_rule("A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0")
-    assert "y" in system.signature["A"]
+    assert "y" in system.signatures["A"]
     assert all("y" in a.interface for a in system.mixture.agents if a.type == "A")
     system.mixture.add("A(y[.])", 1)  # no error now
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -438,7 +438,8 @@ def test_signature_expands_on_add_rule():
         system.mixture.add("A(y[.])", 1)
     with pytest.raises(ValueError, match="not declared"):
         system.mixture.add("D()", 1)
-    system.add_rule("A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0")
+    with pytest.warns(RuntimeWarning, match="introduced new sites to A: y"):
+        system.add_rule("A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0")
     assert "y" in system.signatures["A"]
     assert all("y" in a.interface for a in system.mixture.agents if a.type == "A")
     system.mixture.add("A(y[.])", 1)  # no error now

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -477,3 +477,30 @@ def test_site_defaults():
     assert agent["x"].state == "x"
     assert agent["y"].state == "p"
     assert agent["z"].state == "u"
+
+
+def test_apply_state_change():
+    system = System.from_ka("""
+        %init: 5 A(x{u})
+        %obs: 'phospho' |A(x{p})|
+        A(x{u}) -> A(x{p}) @ 1
+    """)
+    assert system["phospho"] == 0
+    system.apply("A(x{u}) -> A(x{p})")
+    assert system["phospho"] == 1
+    system.apply("A(x{u}) -> A(x{p})", n=4)
+    assert system["phospho"] == 5
+    assert system.time == 0  # time must not advance
+
+
+def test_apply_bond_formation_and_breaking():
+    system = System.from_ka("""
+        %init: 4 A(x[.])
+        %init: 4 B(x[.])
+        %obs: 'AB' |A(x[1]), B(x[1])|
+    """)
+    assert system["AB"] == 0
+    system.apply("A(x[.]), B(x[.]) -> A(x[1]), B(x[1])", n=3)
+    assert system["AB"] == 3
+    system.apply("A(x[1]), B(x[1]) -> A(x[.]), B(x[.])", n=2)
+    assert system["AB"] == 1

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -165,7 +165,6 @@ def test_system_manipulation():
     system = System.from_ka("""
         %init: 10 A(x[.])
         %init: 10 B(x[.])
-        %init: 1 C()
 
         %obs: 'A' |A(x[.])|
         %obs: 'B' |B(x[.])|
@@ -205,15 +204,15 @@ def test_system_manipulation():
 
     # Set a new observable
     system["C"] = "|C()|"
-    assert system["C"] == 1
+    assert system["C"] == 0
     system.update()
-    assert system["C"] == 1
+    assert system["C"] == 0
 
     # Add a rule
     system.add_rule("B() -> C() @ 1000", name="new")
     while system.reactivity:
         system.update()
-    assert system["B"] == 0 and system["C"] == 12
+    assert system["B"] == 0 and system["C"] == 11
 
     # Remove rules
     system.remove_rule("r0")
@@ -223,7 +222,7 @@ def test_system_manipulation():
         system.update()
         print(system.tallies_str)
         print(f"A: {system["A"]}, B: {system["B"]}, C: {system["C"]}\n")
-    assert system["C"] == 0 and system["B"] == 12
+    assert system["C"] == 0 and system["B"] == 11
 
 
 def test_reproducibility_from_initialization():
@@ -437,6 +436,8 @@ def test_signature_expands_on_add_rule():
     )
     with pytest.raises(ValueError, match="unknown site"):
         system.mixture.add("A(y[.])", 1)
+    with pytest.raises(ValueError, match="not declared"):
+        system.mixture.add("D()", 1)
     system.add_rule("A(y[.]), C(y[.]) -> A(y[1]), C(y[1]) @ 1.0")
     assert "y" in system.signatures["A"]
     assert all("y" in a.interface for a in system.mixture.agents if a.type == "A")
@@ -457,15 +458,9 @@ def test_signature_rejects_unknown_sites(make_system):
         make_system().mixture.add("A(y[.])", 1)
 
 
-@pytest.mark.parametrize(
-    "make_system",
-    [
-        lambda: System.from_kappa(
-            rules=["A(x[.]), B(x[.]) <-> A(x[1]), B(x[1]) @ 1.0, 1.0"]
-        ),
-        lambda: System.from_ka("A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"),
-    ],
-)
-def test_signature_rejects_unknown_sites(make_system):
-    with pytest.raises(ValueError, match="unknown site"):
-        make_system().mixture.add("A(y[.])", 1)
+def test_undeclared_agent_type_rejected():
+    system = System.from_kappa(rules=["A(x[.]), B(x[.]) -> A(x[1]), B(x[1]) @ 1.0"])
+    with pytest.raises(ValueError, match="not declared"):
+        system.mixture.add("A(y[.])", 1)
+    with pytest.raises(ValueError, match="not declared"):
+        system.mixture.add("C()", 1)

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -465,3 +465,15 @@ def test_undeclared_agent_and_site_rejected():
         system.mixture.add("A(y[.])")
     with pytest.raises(ValueError, match="not declared"):
         system.mixture.add("C()")
+
+
+def test_site_defaults():
+    system = System.from_kappa({"A()": 1})
+    system.set_site_defaults("A", x="x", y="p", z="u")
+    system.add_rule("A(x[.]), A(y[.]) -> A(x[1]), A(y[1]) @ 1")
+    system.add_rule("A(z[.]), B(z[.]) -> A(z[1]), B(z[1]) @ 1")
+
+    agent = system.mixture.agents[0]
+    assert agent["x"].state == "x"
+    assert agent["y"].state == "p"
+    assert agent["z"].state == "u"


### PR DESCRIPTION
- infer agent signatures from rules
- ensure the interface of each agent added to mixture is consistent with its signature
- adjust interfaces of existing agents if a new rule specifies a new site (with a warning)
- disallow adding agents unmentioned in rules
- allow specifying default site states using a `System` method

addresses #25 