### PR TITLE
add interrupt handler

### DIFF
--- a/pykappa/_utils.py
+++ b/pykappa/_utils.py
@@ -1,7 +1,77 @@
 import random
+import signal
+import functools
+import threading
 from typing import Any, Optional, Iterable, Generic, TypeVar
 from collections.abc import Callable, Hashable, Mapping
 from types import MappingProxyType
+
+
+class _InterruptGuard:
+    """A reentrant guard that defers ``SIGINT`` while a critical section runs."""
+
+    def __init__(self):
+        self._depth = 0
+        self._pending: Optional[tuple] = None
+        self._original: Any = None
+        # A stable reference: each ``self._handler`` access makes a fresh bound
+        # method, so we pin one for identity comparisons against getsignal().
+        self._handler_ref = self._handler
+
+    def _handler(self, signum, frame):
+        if self._depth > 0:
+            # Inside a critical section: defer, keeping the first interrupt.
+            if self._pending is None:
+                self._pending = (signum, frame)
+        else:
+            # Idle: behave as the handler we replaced would have.
+            self._surface(signum, frame)
+
+    def _surface(self, signum, frame):
+        original = self._original
+        if original is signal.SIG_IGN:
+            return
+        if callable(original):
+            original(signum, frame)
+        else:  # SIG_DFL, or None when no Python handler was installed
+            raise KeyboardInterrupt
+
+    def __enter__(self):
+        # Install (or re-install, if the handler was replaced) lazily. The
+        # caller guarantees this only runs on the main thread.
+        if signal.getsignal(signal.SIGINT) is not self._handler_ref:
+            self._original = signal.getsignal(signal.SIGINT)
+            signal.signal(signal.SIGINT, self._handler_ref)
+        self._depth += 1
+        return self
+
+    def __exit__(self, *exc_info):
+        self._depth -= 1
+        if self._depth == 0 and self._pending is not None:
+            pending, self._pending = self._pending, None
+            self._surface(*pending)
+        return False
+
+
+_interrupt_guard = _InterruptGuard()
+
+
+def uninterruptible(func: Callable) -> Callable:
+    """Shield a function from being interrupted midway by a keyboard interrupt.
+
+    The wrapped function will be allowed to finish its execution. Once it
+    completes, the ``KeyboardInterrupt`` will be surfaced to the caller.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        # only the main thread can install signal handlers.
+        if threading.current_thread() is not threading.main_thread():
+            return func(*args, **kwargs)
+        with _interrupt_guard:
+            return func(*args, **kwargs)
+
+    return wrapper
 
 
 def str_table(rows: list[list], header: Optional[list] = None) -> str:

--- a/pykappa/system.py
+++ b/pykappa/system.py
@@ -22,7 +22,7 @@ from pykappa.rule import Rule
 from pykappa.pattern import Component, Pattern, Site
 from pykappa.analysis import Monitor
 from pykappa.expression import Expression
-from pykappa._utils import str_table
+from pykappa._utils import str_table, uninterruptible
 
 
 class System:
@@ -480,6 +480,7 @@ class System:
                 )
             )
 
+    @uninterruptible
     def add(self, pattern: Pattern | Component | str, n_copies: int = 1) -> None:
         """Add instances of a pattern or component to the mixture using inferred agent signatures."""
         if isinstance(pattern, str):
@@ -498,6 +499,7 @@ class System:
                 self._enforce_signature(agent)
             self._mixture._add(copied, n_copies)
 
+    @uninterruptible
     def remove(self, component: Component) -> None:
         """Remove a specific component from the current mixture."""
         self._mixture._remove_component(component)
@@ -507,6 +509,7 @@ class System:
         """The total reactivity of the system."""
         return sum(rule.reactivity(self) for rule in self._rules.values())
 
+    @uninterruptible
     def update(self) -> None:
         """Perform one simulation step."""
 
@@ -547,6 +550,7 @@ class System:
         if self._monitor is not None:
             self._monitor.update()
 
+    @uninterruptible
     def apply(self, transformation: str, n: int = 1) -> None:
         """Apply a transformation immediately for a specified number of times.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,115 @@
+import signal
+import threading
+
+import pytest
+
+from pykappa import _utils
+from pykappa._utils import uninterruptible
+
+
+@pytest.fixture(autouse=True)
+def isolate_sigint():
+    """Give each test a known SIGINT baseline and reset the shared guard state."""
+    guard = _utils._interrupt_guard
+    saved = signal.getsignal(signal.SIGINT)
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    guard._depth = 0
+    guard._pending = None
+    guard._original = None
+    yield
+    guard._depth = 0
+    guard._pending = None
+    signal.signal(signal.SIGINT, saved)
+
+
+def _spin():
+    for _ in range(10000):
+        pass
+
+
+def test_defers_interrupt_until_completion():
+    completed = []
+
+    @uninterruptible
+    def critical():
+        signal.raise_signal(signal.SIGINT)
+        _spin()  # the handler runs here and must only defer, not interrupt
+        completed.append(True)
+
+    with pytest.raises(KeyboardInterrupt):
+        critical()
+    assert completed == [True]  # ran to completion before the interrupt surfaced
+
+
+def test_idle_interrupt_surfaces_immediately():
+    @uninterruptible
+    def noop():
+        pass
+
+    noop()  # installs the persistent handler; guard is now idle
+    with pytest.raises(KeyboardInterrupt):
+        signal.raise_signal(signal.SIGINT)
+        _spin()
+
+
+def test_nested_calls_defer_to_outermost():
+    order = []
+
+    @uninterruptible
+    def inner():
+        signal.raise_signal(signal.SIGINT)
+        _spin()
+        order.append("inner")
+
+    @uninterruptible
+    def outer():
+        inner()
+        order.append("outer")  # deferred past inner's return, so this still runs
+
+    with pytest.raises(KeyboardInterrupt):
+        outer()
+    assert order == ["inner", "outer"]
+
+
+def test_delegates_to_preexisting_handler():
+    calls = []
+
+    def user_handler(signum, frame):
+        calls.append(signum)
+
+    signal.signal(signal.SIGINT, user_handler)
+
+    @uninterruptible
+    def critical():
+        signal.raise_signal(signal.SIGINT)
+        _spin()
+        assert calls == []  # deferred: the user handler has not fired yet
+
+    critical()
+    assert calls == [signal.SIGINT]  # delegated to the original handler on exit
+
+
+def test_ignored_interrupt_is_dropped():
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+    @uninterruptible
+    def critical():
+        signal.raise_signal(signal.SIGINT)
+        _spin()
+
+    critical()  # SIG_IGN was in place, so nothing is surfaced
+
+
+def test_worker_thread_runs_without_installing_a_handler():
+    result = []
+
+    @uninterruptible
+    def work():
+        # Installing a handler off the main thread would raise; the wrapper must
+        # skip the guard entirely here.
+        result.append(True)
+
+    thread = threading.Thread(target=work)
+    thread.start()
+    thread.join()
+    assert result == [True]


### PR DESCRIPTION
This PR prevents the user from corrupting a `System` by interrupting it during simulation. For example, suppose the user runs
```python
# ...
system = System.from_ka("in.ka")
while system.reactivity:
    system.update()
```
in a Jupyter Notebook. If the system state does not converge, this loop will run forever. Should the user interrupt the simulation, `system` may be left in an incomplete state if it was interrupted during `update()`.

We prevent this class of errors by installing our own signal handle to take care of `SIG_INT`. Any PyKappa method prefixed by `@uninterruptable` will defer surfacing the interrupt until the end of the method. Thus `@uninterruptable` functions are, from the perspective of interrupt signals, atomic.

Should a user install their own signal handler, either before or after the first `@uninterruptable` code runs, we will eventually defer to their handler in all cases. If we are executing `@uninterruptable` code, the user's handler will only be called once the method is completed; otherwise, it will run immediately. The net effect is that signals from the user's perspective behave entirely as expected. We only ensure that interrupts cannot disrupt `System` state and leave external behavior untouched.

Note: `update_via_kasim` method call does not take advantage of these benefits. Future work can fix this, but should take care to handle interruption of the `KaSim` subprocess properly.